### PR TITLE
add flag for FF_GITLAB_REGISTRY_HELPER_IMAGE

### DIFF
--- a/jobs/gitlab-runner/spec
+++ b/jobs/gitlab-runner/spec
@@ -51,3 +51,6 @@ properties:
     description: "HTTPS proxy to use"
   env.no_proxy:
     description: "List of comma-separated hosts that should skip connecting to the proxy"
+  env.FF_GITLAB_REGISTRY_HELPER_IMAGE:
+    description: "use the GitLab OCI repository when true (default) or the obsolete Docker Hub"
+    default: "1"

--- a/jobs/gitlab-runner/templates/pre-start
+++ b/jobs/gitlab-runner/templates/pre-start
@@ -46,6 +46,7 @@ runuser -u vcap -- /var/vcap/packages/gitlab-runner/bin/gitlab-runner register \
   --env http_proxy="<%= p('env.http_proxy', '') %>" \
   --env https_proxy="<%= p('env.https_proxy', '') %>" \
   --env no_proxy="<%= p('env.no_proxy', '') %>" \
+  --env FF_GITLAB_REGISTRY_HELPER_IMAGE="<%= p('env.FF_GITLAB_REGISTRY_HELPER_IMAGE', '1') %>" \
   --registration-token <%= p('runner.registration.token') %>
 
 sed -i \


### PR DESCRIPTION
Attempt to mitigate the following error:
```
Pulling docker image registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:x86_64-bd40e3da ...
WARNING: Failed to pull image with policy "always": error pulling image configuration: Get https://cdn.registry.gitlab-static.net/docker/registry/v2/blobs/sha256/8f/8f1a156260bf1fb4870696d9639407096e813e6c71841636bb86542858d949e0/data?Expires=1650879499&KeyName=gprd-registry-cdn&Signature=TvOM7RnWdy2pGvijjxWnyR___4w=: Forbidden (manager.go:203:1s)
```

References:
- <https://gitlab.com/gitlab-org/gitlab-runner/-/issues/27218>
- <https://gitlab.com/gitlab-org/gitlab-runner/-/issues/27196>
- <https://gitlab.com/gitlab-org/gitlab-runner/-/issues/28727>