### PR TITLE
set the Docker pull policy

### DIFF
--- a/jobs/gitlab-runner/spec
+++ b/jobs/gitlab-runner/spec
@@ -30,6 +30,12 @@ properties:
   runner.docker_host:
     description: Host when using docker executor
     default: unix:///var/vcap/sys/run/docker/docker.sock
+  runner.docker_pull_policy_always:
+    description: Set "always" to the image pull policy (default).
+    default: true
+  runner.docker_pull_policy_ifnotpresent:
+    description: Set "if-not-present" to the image pull policy.
+    default: false
   runner.docker_privileged:
     description: Should runner run in privileged mode for docker executor
     default: true

--- a/jobs/gitlab-runner/templates/pre-start
+++ b/jobs/gitlab-runner/templates/pre-start
@@ -33,6 +33,12 @@ runuser -u vcap -- /var/vcap/packages/gitlab-runner/bin/gitlab-runner register \
   <% end -%>
   --docker-image <%= p('runner.docker_image') %> \
   --docker-host <%= p('runner.docker_host') %> \
+  <% if p('runner.docker_pull_policy_always') then -%>
+  --docker-pull-policy="always" \
+  <% end -%>
+  <% if p('runner.docker_pull_policy_ifnotpresent') then -%>
+  --docker-pull-policy="if-not-present" \
+  <% end -%>
 <% end -%>
   --url "<%= p('runner.registration.url') %>" \
 <% if_p('runner.tags') do | tags | -%>


### PR DESCRIPTION
Quoting the documentation:
> [⋯]
> This functionality can be useful when the Docker registry is not available and you need to increase job resiliency.
> If you use the always policy and the registry is not available, the job fails even if the desired image is cached locally.
>
> To overcome that behavior, you can add additional fallback pull policies that execute in case of failure.
> By adding a second pull policy value of if-not-present, the runner finds any locally-cached Docker image layers:
> ```toml
> [runners.docker]
>   pull_policy = ["always", "if-not-present"]
> ```

References:
- <https://gitlab.com/gitlab-org/gitlab-runner/-/issues/26558>
- <https://gitlab.com/gitlab-org/gitlab-runner/-/blob/v14.10.0/docs/executors/docker.md#using-multiple-pull-policies>